### PR TITLE
Fixed issue #21

### DIFF
--- a/FameBot/Core/Plugin.cs
+++ b/FameBot/Core/Plugin.cs
@@ -814,15 +814,12 @@ namespace FameBot.Core
         /// <param name="tolerance">The distance (in game tiles) </param>
         private void CalculateMovement(Client client, Location targetPosition, float tolerance)
         {
-            if (flashPtr != GetForegroundWindow()) //Check if the flashplayer has focus
-            {
-                //If not set all keys to false
+
                 A_PRESSED = false;
                 D_PRESSED = false;
                 W_PRESSED = false;
                 S_PRESSED = false;
-            }
-            // Left or right
+            
             if (client.PlayerData.Pos.X < targetPosition.X - tolerance)
             {
                 // Move right

--- a/FameBot/Core/Plugin.cs
+++ b/FameBot/Core/Plugin.cs
@@ -821,7 +821,6 @@ namespace FameBot.Core
                 D_PRESSED = false;
                 W_PRESSED = false;
                 S_PRESSED = false;
-                return;
             }
             // Left or right
             if (client.PlayerData.Pos.X < targetPosition.X - tolerance)

--- a/FameBot/Core/Plugin.cs
+++ b/FameBot/Core/Plugin.cs
@@ -814,6 +814,15 @@ namespace FameBot.Core
         /// <param name="tolerance">The distance (in game tiles) </param>
         private void CalculateMovement(Client client, Location targetPosition, float tolerance)
         {
+            if (flashPtr != GetForegroundWindow()) //Check if the flashplayer has focus
+            {
+                //If not set all keys to false
+                A_PRESSED = false;
+                D_PRESSED = false;
+                W_PRESSED = false;
+                S_PRESSED = false;
+                return;
+            }
             // Left or right
             if (client.PlayerData.Pos.X < targetPosition.X - tolerance)
             {

--- a/FameBot/Core/Plugin.cs
+++ b/FameBot/Core/Plugin.cs
@@ -328,26 +328,33 @@ namespace FameBot.Core
             //Focus checker
             new Thread(() => 
             {
-                IntPtr latestWindow = GetForegroundWindow();
-                do
+                Thread.CurrentThread.IsBackground = true;
+                try
                 {
-                    if (GetForegroundWindow() != latestWindow) //If focus changed
+                    IntPtr latestWindow = GetForegroundWindow();
+                    do
                     {
-                        if (latestWindow == flashPtr) //If older focus was the flash player
+                        if (GetForegroundWindow() != latestWindow) //If focus changed
                         {
-                            W_PRESSED = false;
-                            S_PRESSED = false;
-                            D_PRESSED = false;
-                            A_PRESSED = false;
-                            latestWindow = GetForegroundWindow();
-                            CalculateMovement(connectedClient, latestLocation, latestTolerance); //Recalculate movement to get back on track
-                        }else
-                        {
-                            latestWindow = GetForegroundWindow();
+                            if (latestWindow == flashPtr) //If older focus was the flash player
+                            {
+                                W_PRESSED = false;
+                                S_PRESSED = false;
+                                D_PRESSED = false;
+                                A_PRESSED = false;
+                                latestWindow = GetForegroundWindow();
+                                CalculateMovement(connectedClient, latestLocation, latestTolerance); //Recalculate movement to get back on track
+                            }
+                            else
+                            {
+                                latestWindow = GetForegroundWindow();
+                            }
                         }
-                    }
-                    Thread.Sleep(200);
-                } while (enabled);
+                        Thread.Sleep(200);
+                    } while (enabled);
+                    Console.WriteLine("Thread closed");
+                }
+                catch(Exception ex) { Console.WriteLine(ex.ToString()); }
             }).Start();
 
             if (enabled)


### PR DESCRIPTION
Ok so now it's fixed I think.

When I would deactivate w_pressed etc. on the older commits it would stop moving correctly.

My solution:
Started a new thread that runs while famebot is enabled
Every 200ms it checks if the ForegroundWindow has changed.
If it has, if the old foreground window wasnt the flashplayer, just set the variable of the old foreground window to the new one.
If the old foreground window was the flashplayer (which would mean the bug would occur)
Set all w_pressed etc. to false, and re-run calculateMovement with the last specifications that were ran.

I added 2 variables latestTolerance and latestTargetPosition that get updated with each calculatemovement
and are used by the thread to recalculate movement after disabling all the "pressed"'s

## Why I added a new thread
To avoid referencing the System.Windows.Automation dll to check when a window loses focus.
It's a cheaty-ish way to check if focus changes and it works nicely and cpu usage looks the same to me. 
